### PR TITLE
Various enhancements to RDS module

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module "db" {
   # Master user name. Password is automatically generated and should
   # be IMMEDIATELY reset via the AWS console or CLI.
   #
-  # NOTE: Initial # password may show up in logs, and it is stored in
+  # NOTE: Initial password may show up in logs, and is stored in
   # the Terraform state file.
   username = "foobar"
   port     = 5432
@@ -110,45 +110,46 @@ module "db" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| allocated_storage | The allocated storage in gigabytes | string | - | yes |
-| allow_major_version_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
+| allocated\_storage | The allocated storage in gigabytes | string | - | yes |
+| allow\_major\_version\_upgrade | Indicates that major version upgrades are allowed. Changing this parameter does not result in an outage and the change is asynchronously applied as soon as possible | string | `false` | no |
 | apply_immediately | Specifies whether any database modifications are applied immediately, or during the next maintenance window | string | `false` | no |
-| auto_minor_version_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
-| availability_zone | The Availability Zone of the RDS instance | string | `` | no |
-| backup_retention_period | The days to retain backups for | number | `1` | no |
+| auto\_minor\_version\_upgrade | Indicates that minor engine upgrades will be applied automatically to the DB instance during the maintenance window | bool | `true` | no |
+| availability_zone | The availability zone of the RDS instance | string | `` | no |
+| backup\_retention\_period | The days to retain backups for | number | `1` | no |
 | backup_window | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window | string | - | yes |
-| character_set_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
-| copy_tags_to_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | number | `false` | no |
-| db_subnet_group_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
-| deletion_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
-| enabled_cloudwatch_logs_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | string | `<list>` | no |
+| character\_set\_name | (Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information | string | `` | no |
+| copy\_tags\_to\_snapshot | On delete, copy all Instance tags to the final snapshot (if final_snapshot_identifier is specified) | number | `false` | no |
+| db\_subnet\_group\_name | Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group. If unspecified, will be created in the default VPC | string | `` | no |
+| deletion\_protection | The database can't be deleted when this value is set to true. | string | `false` | no |
+| enabled\_cloudwatch\_logs\_exports | List of log types to enable for exporting to CloudWatch logs. If omitted, no logs will be exported. Valid values (depending on engine): alert, audit, error, general, listener, slowquery, trace. | string | `<list>` | no |
 | engine | The database engine to use | string | - | yes |
-| engine_version | The engine version to use | string | - | yes |
-| final_snapshot_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
-| iam_database_authentication_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
+| engine\_version | The engine version to use | string | - | yes |
+| final\_snapshot\_identifier | The name of your final DB snapshot when this DB instance is deleted. | string | `false` | no |
+| iam\_database\_authentication\_enabled | Specifies whether or mappings of AWS Identity and Access Management (IAM) accounts to database accounts is enabled | string | `false` | no |
 | identifier | The name of the RDS instance. If omitted, Terraform will assign a random, unique identifier | string | - | yes |
-| instance_class | The instance type of the RDS instance | string | - | yes |
+| instance\_class | The instance type of the RDS instance | string | - | yes |
 | iops | The amount of provisioned IOPS. Setting this implies a storage_type of 'io1' | string | `0` | no |
-| kms_key_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and kms_key_id is not specified the default KMS key created in your account will be used | string | `` | no |
-| license_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
+| kms\_key\_id | The ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN. If storage_encrypted is set to true and `kms_key_id` is not specified, the default KMS key created in your account will be used | string | `` | no |
+| license\_model | License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1 | string | `` | no |
 | maintenance_window | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | string | - | yes |
-| ~~monitoring_interval~~ | ~~The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.~~ | ~~string~~ | ~~`0`~~ | ~~no~~ |
-| ~~monitoring_role_arn~~ | ~~ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero.~~ | ~~string~~ | ~~``~~ | ~~no~~ |
-| ~~monitoring_role_name~~ | ~~Name of the IAM role which will be created when create_monitoring_role is enabled.~~ | ~~string~~ | ~~`rds-monitoring-role`~~ | ~~no~~ |
-| multi_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
+| max\_allocated\_storage | When configured, the upper limit to which Amazon RDS can automatically scale the storage of the DB instance (in gigabytes) | string | - | no |
+| ~~monitoring\_interval~~ | ~~The interval, in seconds, between points when Enhanced Monitoring metrics are collected for the DB instance. To disable collecting Enhanced Monitoring metrics, specify 0. The default is 0. Valid Values: 0, 1, 5, 10, 15, 30, 60.~~ | ~~string~~ | ~~`0`~~ | ~~no~~ |
+| ~~monitoring\_role\_arn~~ | ~~ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring\_interval is non-zero.~~ | ~~string~~ | ~~``~~ | ~~no~~ |
+| ~~monitoring\_role\_name~~ | ~~Name of the IAM role which will be created when create\_monitoring\_role is enabled.~~ | ~~string~~ | ~~`rds-monitoring-role`~~ | ~~no~~ |
+| multi\_az | Specifies if the RDS instance is multi-AZ | string | `false` | no |
 | name | The DB name to create. If omitted, no database is created initially. | string | `` | no |
-| option_group_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
-| parameter_group_name | Name of the DB parameter group to associate. | string | `` | no |
+| option\_group\_name | Name of the DB option group to associate. Setting this automatically disables option_group creation | string | `` | no |
+| parameter\_group\_name | Name of the DB parameter group to associate. | string | `` | no |
 | port | The port on which the DB accepts connections | string | - | yes |
-| publicly_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
-| replicate_source_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS Database to replicate. | string | `` | no |
-| security_group_names | Additonal security groups to associated with the task or service. This is a space delimited string list of security group names. | - | no |
-| skip_final_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from final_snapshot_identifier | bool | `true` | no |
-| snapshot_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
-| storage_encrypted | Specifies whether the DB instance is encrypted | bool | `false` | no |
-| storage_type | One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'. | string | `gp2` | no |
-| tags | A mapping of tags to assign to all resources | string | `<map>` | no |
-| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times | map | `<map>` | no |
+| publicly\_accessible | Bool to control if instance is publicly accessible | bool | `false` | no |
+| replicate\_source\_db | Specifies that this resource is a Replicate database, and to use this value as the source database. This correlates to the identifier of another Amazon RDS database to replicate. | string | `` | no |
+| security\_group\_names | Additonal security groups to associated with the task or service. This is a space delimited string list of security group names. | - | no |
+| skip\_final\_snapshot | Determines whether a final DB snapshot is created before the DB instance is deleted. If true is specified, no DBSnapshot is created. If false is specified, a DB snapshot is created before the DB instance is deleted, using the value from `final_snapshot_identifier` | bool | `true` | no |
+| snapshot\_identifier | Specifies whether or not to create this database from a snapshot. This correlates to the snapshot ID you'd find in the RDS console, e.g: rds:production-2015-06-26-06-05. | string | `` | no |
+| storage\_encrypted | Specifies whether the DB instance is encrypted | bool | `true` | no |
+| storage_type | One of the supported storage types | string | - | yes |
+| tags | A mapping of tags to assign to resources where supported | string | `<map>` | no |
+| timeouts | (Optional) Updated Terraform resource management timeouts. Applies to `aws_db_instance` in particular to permit resource management times (see the [Terraform doumentation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance#timeouts) for further details | object | `<object>` | no |
 | username | Username for the master DB user | string | - | yes |
 
 ## Outputs

--- a/variables.tf
+++ b/variables.tf
@@ -24,7 +24,7 @@ variable "auto_minor_version_upgrade" {
 
 variable "availability_zone" {
   description = "Availability zone"
-  default     = ""
+  default     = null
 }
 
 variable "backup_retention_period" {
@@ -39,7 +39,7 @@ variable "backup_window" {
 
 variable "character_set_name" {
   description = "(Optional) The character set name to use for DB encoding in Oracle instances. This can't be changed. See Oracle Character Sets Supported in Amazon RDS for more information"
-  default     = ""
+  default     = null
 }
 
 variable "copy_tags_to_snapshot" {
@@ -53,7 +53,7 @@ variable "db_name" {
 
 variable "db_subnet_group_name" {
   description = "Database subnet group name; instance will be created in the associated VPC"
-  default     = ""
+  default     = null
 }
 
 variable "deletion_protection" {
@@ -73,12 +73,12 @@ variable "engine" {
 
 variable "engine_version" {
   description = "Engine version to use"
-  default     = ""
+  default     = null
 }
 
 variable "final_snapshot_identifier" {
   description = "Computed by default. Without a final snapshot, you will be unable to restore the data in a deleted RDS instance"
-  default     = ""
+  default     = null
 }
 
 variable "iam_database_authentication_enabled" {
@@ -97,22 +97,22 @@ variable "instance_class" {
 
 variable "iops" {
   description = "The amount of provisioned IOPS. Setting this implies a storage_type of 'io1'"
-  default     = 0
+  default     = null
 }
 
 variable "kms_key_id" {
   description = "ARN for the KMS encryption key. If creating an encrypted replica, set this to the destination KMS ARN."
-  default     = ""
+  default     = null
 }
 
 variable "license_model" {
   description = "License model information for this DB instance. Optional, but required for some DB engines, i.e. Oracle SE1"
-  default     = ""
+  default     = null
 }
 
 variable "maintenance_window" {
   description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'"
-  default     = ""
+  default     = null
 }
 
 # variable "monitoring_interval" {
@@ -122,7 +122,7 @@ variable "maintenance_window" {
 
 # variable "monitoring_role_arn" {
 #   description = "The ARN for the IAM role that permits RDS to send enhanced monitoring metrics to CloudWatch Logs. Must be specified if monitoring_interval is non-zero."
-#   default     = ""
+#   default     = null
 # }
 
 # variable "monitoring_role_name" {
@@ -137,12 +137,12 @@ variable "multi_az" {
 
 variable "option_group_name" {
   description = "Name of the DB option group to associate"
-  default     = ""
+  default     = null
 }
 
 variable "parameter_group_name" {
   description = "Name of the DB parameter group to associate"
-  default     = ""
+  default     = null
 }
 
 variable "port" {
@@ -161,7 +161,9 @@ variable "replicate_source_db" {
 }
 
 variable "security_group_names" {
-  description = "Space-delimited string containing security group names"
+  description = "List of security group names"
+  type        = list(string)
+  default     = []
 }
 
 variable "skip_final_snapshot" {
@@ -172,7 +174,7 @@ variable "skip_final_snapshot" {
 # TODO: Determine how to simplify management of dump to snapshot and load from snapshot, and whether default values can be computed.
 variable "snapshot_identifier" {
   description = "If specified, use the named snapshot to create the database. The snapshot ID can be found in the RDS console, e.g: rds:service-2015-06-26-06-05."
-  default     = ""
+  default     = null
 }
 
 variable "storage_encrypted" {
@@ -181,8 +183,7 @@ variable "storage_encrypted" {
 }
 
 variable "storage_type" {
-  description = "One of 'standard' (magnetic), 'gp2' (general purpose SSD), or 'io1' (provisioned IOPS SSD). The default is 'io1' if iops is specified, 'standard' if not. Note that this behaviour is different from the AWS web console, where the default is 'gp2'."
-  default     = "gp2"
+  description = "One of the supported storage types"
 }
 
 variable "tags" {
@@ -193,13 +194,12 @@ variable "tags" {
 
 variable "timeouts" {
   description = "(Optional) Terraform resource management timeouts"
-  type        = map(string)
-
-  default = {
-    create = "40m"
-    update = "80m"
-    delete = "40m"
-  }
+  type = object({
+    create = optional(string)
+    delete = optional(string)
+    update = optional(string)
+  })
+  default = null
 }
 
 variable "username" {


### PR DESCRIPTION
*   Remove default storage_type value. The set of valid storage types may change over the long-haul, and the user should choose a value appropriate to the application.

*   Update README.md

    *   Correct typo and markdown formatting issues.
    *   Add previously-undocumented `max_allocated_storage` variable.
    *   Update `storage_type` description and default.

*   Change input variable defaults from empty string to null.

*   Remove default timeouts and make variable definition more precise. Let AWS use its built-in defaults rather than creating our own.

*   Change `security_group_names` variable to a list of strings instead of a space-delimited string.