### PR TITLE
Enhancements to terraform-aws-rds module (mostly for option-group submodule)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Provide an [RDS database instance](https://www.terraform.io/docs/providers/aws/r/db_instance.html).
 
+Also provides submodules for managing other resources related to RDS. The following submodules are supported.
+
+* [option-group](modules/option-group/README.md)
+* parameter-group – **not yet integrated**
+
 Use the [terraform-aws-client-server-security-group](https://github.com/techservicesillinois/terraform-aws-client-server-security-group) module to create security groups
 to be used by clients and servers of this RDS instance. The referred-to module
 creates two RDS security groups – one a client security group, and the other a

--- a/modules/option-group/README.md
+++ b/modules/option-group/README.md
@@ -1,4 +1,4 @@
-# rds/modules/option-group
+# option-group
 
 Manage an RDS option group.
 
@@ -11,12 +11,18 @@ module "rds-option-group" {
   engine         = "oracle-ee"
   engine_version = "19"
 
-  # Prefix for option group name.
-  prefix = "s3-integration"
+  description = "Enable S3 integration for database migration"
+  name_suffix = "db-migration-s3-integration"
 
-  options = [
-    "S3_INTTEGRATION"
+  option = [
+    {
+    option_name = "S3_INTEGRATION"
+    }
   ]
+
+  tags = {
+    Service = "dba-migrate"
+  }
 }
 ```
 
@@ -27,7 +33,7 @@ The following arguments are supported:
 
 * `engine` - (Required) Engine name to which option group applies
 
-* `engine_version` - (Required) Major engine version to which group applies
+* `engine_version` - (Required) Major engine version to which option group applies
 
 * `option` - (Optional) List of option objects to include in the option group. Note that options differ from one RDS engine to another. A full list of all options for a given RDS engine can be discovered via the AWS command line interface by running
 
@@ -35,11 +41,11 @@ The following arguments are supported:
   aws rds describe-option-group-options --engine-name <rds_engine_name>
   ```
 
-* `prefix` - (Required) Prefix for option group name. The full name is generated from the prefix and the engine name and engine version. The prefix may contain only letters, digits, or hyphens. See [Working with DB option groups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html) for additional restrictions.
+* `name_suffix` - (Required) Suffix for option group name. The full name is generated from the engine name, engine version, and the suffix. The suffix may contain only letters, digits, or hyphens. See [Working with DB option groups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithOptionGroups.html) for additional restrictions.
 
 * `tags` - (Optional) Tags to be applied to resources where supported.
 
-* `timeouts` - (Optional) Map of timeouts for the AWS API when working with this resource. The only timeout available for this module is the delete timeout and should be an item in the map with a key of `delete`
+* `timeouts` - (Optional) Map of timeouts for the AWS API when working with this resource. The only timeout available for this module is the delete timeout and should be an item in the map with a key of `delete`.
 
 * `security_group_names` - (Optional) A list of VPC security group names that apply to these options
 
@@ -48,19 +54,19 @@ The following arguments are supported:
 
 An `option` block consists of a list containing one or more objects, each of which may contain the following attributes:
 
-* `option_name` - (Required) Name of the option to enable
+* `option_name` - (Required) Name of the option to enable.
 
-* `option_settings` - (Optional) A list of option setting maps, each containing a setting that applies to this option. Each map must contain an `name` elemenet and a `value` element.
+* `option_settings` - (Optional) A list of option setting maps, each containing a setting that applies to this option. Each map must contain an `name` element and a `value` element.
 
-* `port` - (Optional) Port number for this option
+* `port` - (Optional) Port number for this option.
 
-* `version` - (Optional) version string for this option
+* `version` - (Optional) version string for this option.
 
 Attributes Reference
 --------------------
 
 The following attributes are exported:
 
-* `arn` - The Amazon Resource Name of the option group.
+* `arn` - Amazon Resource Name of the option group.
 
-* `name` - The name of the db option group.
+* `name` - name of the RDS option group.

--- a/modules/option-group/main.tf
+++ b/modules/option-group/main.tf
@@ -1,5 +1,6 @@
 locals {
-  og_name = format("%s-%s-%s", var.name_prefix, var.engine, replace(var.engine_version, ".", "-"))
+  og_description = (var.description != null) ? var.description : format("%s option group", local.og_name)
+  og_name        = format("%s-%s-%s", var.engine, replace(var.engine_version, ".", "-"), var.name_suffix)
 }
 
 # todo: module should allow a separate VPC security group to be supplied
@@ -11,10 +12,10 @@ data "aws_security_group" "selected" {
 
 resource "aws_db_option_group" "default" {
   name                     = local.og_name
-  option_group_description = format("%s option group", local.og_name)
+  option_group_description = local.og_description
   engine_name              = var.engine
   major_engine_version     = var.engine_version
-  tags                     = merge({ Name = var.name_prefix }, var.tags)
+  tags                     = merge({ Name = var.name_suffix }, var.tags)
 
   dynamic "option" {
     for_each = toset(var.option != null ? var.option : [])

--- a/modules/option-group/variables.tf
+++ b/modules/option-group/variables.tf
@@ -1,9 +1,18 @@
+variable "description" {
+  description = "Description of option group"
+  default     = null
+}
+
 variable "engine" {
   description = "Database engine to which group applies"
 }
 
 variable "engine_version" {
   description = "Major engine version to which group applies"
+}
+
+variable "name_suffix" {
+  description = "Suffix for option group name (appended after engine and engine_version)"
 }
 
 variable "option" {
@@ -19,8 +28,10 @@ variable "option" {
   }))
 }
 
-variable "name_prefix" {
-  description = "Prefix for option group name"
+variable "security_group_names" {
+  description = "List of VPC security group names used for these options"
+  type        = list(string)
+  default     = []
 }
 
 variable "tags" {
@@ -35,10 +46,4 @@ variable "timeouts" {
     delete = optional(string)
   })
   default = null
-}
-
-variable "security_group_names" {
-  description = "A list of VPC security group names used for these options"
-  type        = list(string)
-  default     = []
 }


### PR DESCRIPTION
*   For option-group submodule, change `name_prefix` variable to `name_suffix`, because that allows option groups to sort by engine name and engine version.

*   Changes to `modules/option-group/README.md` to fix erroneous data structure examples, typos, and the like.

*   Add optional description variable with logic to set default value if no description is specified by caller.

*   Add hyperlink to top-level README.md to point to the option-group submodule.