### PR TITLE
Add lifecycle rule for allocated_storage

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,7 @@ resource "aws_db_instance" "default" {
 
   lifecycle {
     ignore_changes = [
+      allocated_storage,
       engine_version,
       password,
     ]


### PR DESCRIPTION
Since allocated_storage can never be reduced below the baseline value, we add an "ignore_changes" lifecycle rule. Storage allocation increases should be made automatically if max_allocated_storage is set.