### PR TITLE
Wait until instance is created before creating feature roles

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_db_instance" "default" {
 
 resource "aws_db_instance_role_association" "default" {
   for_each               = var.feature_role_arns
-  db_instance_identifier = var.identifier
+  db_instance_identifier = aws_db_instance.default.identifier
   feature_name           = each.key
   role_arn               = each.value
 }


### PR DESCRIPTION
When adding a feature_role_arn at the time of creation, the previous code didn't realize the dependency and tried to create the role right away using the not-yet-existent RDS instance. This fix establishes the dependency so that the role won't be created until after the instance exists.