### PR TITLE
Add RDS event subscription module

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Provide an [RDS database instance](https://www.terraform.io/docs/providers/aws/r
 
 Also provides submodules for managing other resources related to RDS. The following submodules are supported.
 
+* [event-subscription](modules/event-subscription/README.md)
 * [option-group](modules/option-group/README.md)
 * parameter-group – **not yet integrated**
 

--- a/modules/event-subscription/README.md
+++ b/modules/event-subscription/README.md
@@ -1,0 +1,49 @@
+# event-subscription
+
+Subscribe specified RDS events for specified RDS instancs to an Amazon SNS topic.
+
+## Usage
+
+```hcl
+module "rds-reserved-instance" {
+  source = "modules/event-subscription"
+
+  event_categories = [
+    "failover",
+    "failure",
+    "low storage",
+    "maintenance",
+  ]
+  instance_names = [
+    "bar-db",
+    "foo-db",
+  ]
+  sns_topic = "rds-notify"
+
+  tags = {
+    Service = "foobar"
+  }
+}
+```
+
+Argument Reference
+-----------------
+
+The following arguments are supported:
+
+* `event_categories` - (Optional) List of event categories for a SourceType that you want to subscribe to. See [Working with Amazon RDS event notification](http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Events.html) or run `aws rds describe-event-categories`.
+
+* `instance_names` - (Optional) List of database identifiers (RDS instance names) for which events will be returned; empty list specifies all databases in this account and region
+
+* `tags` - (Optional) Tags to be applied to resources where supported
+
+* `sns_topic` - (Required) Name of SNS topic to which events are published
+
+Attributes Reference
+--------------------
+
+The following attributes are exported:
+
+* `aws_db_event_subscription` - Amazon Resource Name of the reserved instance
+
+* `sns_topic_arn` - SNS topic ARN

--- a/modules/event-subscription/main.tf
+++ b/modules/event-subscription/main.tf
@@ -1,0 +1,29 @@
+data "aws_db_instances" "selected" {
+  # If var.instance_names is null, omit filter, matching all RDS instances.
+  for_each = toset(var.instance_names != null ? [""] : [])
+  filter {
+    name   = "db-instance-id"
+    values = var.instance_names
+  }
+}
+
+# Retrieve existing RDS event by name.
+
+data "aws_sns_topic" "selected" {
+  name = var.sns_topic
+}
+
+# TODO: This creates one subscription per RDS resource; if we're satisfied
+# with a single subscription name, we can bunch all resources into a
+# single subscription. This is a choice between simplicity and robustness.
+
+resource "aws_db_event_subscription" "default" {
+  for_each = toset(data.aws_db_instances.selected[""].instance_identifiers)
+
+  event_categories = var.event_categories
+  name             = format("rds-event-%s", each.key)
+  sns_topic        = data.aws_sns_topic.selected.arn
+  source_type      = "db-instance"
+  source_ids       = [each.key]
+  tags             = merge({ Name = each.key }, var.tags)
+}

--- a/modules/event-subscription/outputs.tf
+++ b/modules/event-subscription/outputs.tf
@@ -1,0 +1,12 @@
+# TODO: Keep for debugging?
+#output "zzzzz" {
+# value = aws_db_event_subscription.default
+# }
+
+output "aws_db_event_subscription" {
+  value = { for name, sub in aws_db_event_subscription.default : name => sub.arn }
+}
+
+output "sns_topic_arn" {
+  value = data.aws_sns_topic.selected.arn
+}

--- a/modules/event-subscription/variables.tf
+++ b/modules/event-subscription/variables.tf
@@ -1,0 +1,21 @@
+variable "event_categories" {
+  description = "List of event categories to which to subscribe"
+  type        = list(string)
+  default     = []
+}
+
+variable "instance_names" {
+  description = "List of database identifiers for which events will be returned; empty list specifies all databases in this account and region"
+  type        = list(string)
+  default     = null
+}
+
+variable "sns_topic" {
+  description = "SNS topic"
+}
+
+variable "tags" {
+  description = "Tags to be applied to resources where supported"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
Allow subscribing to RDS events for some or all RDS instances in this account and region.

Update top-level documentation to refer to new submodule's documentation.